### PR TITLE
switching to JSON-LD resource specific context

### DIFF
--- a/context.jsonld
+++ b/context.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": [
+    "https://rawgit.com/valueflows/valueflows/master/context.jsonld",
+    {
+      "Resource": "vf:Resource"
+    }
+  ],
+  "@graph": [
+    {
+        "@id": "Resource",
+        "@type": "owl:Class",
+        "rdfs:label": {
+            "en": "Resource"
+        }
+    }
+  ]
+}

--- a/examples/valueflows.jsonld
+++ b/examples/valueflows.jsonld
@@ -1,10 +1,9 @@
 {
   "@context": [
     "https://w3id.org/role/",
-    "https://rawgit.com/valueflows/agent/master/context.jsonld",
+    "https://rawgit.com/valueflows/resource/master/context.jsonld",
     {
-      "role": "https://w3id.org/role/",
-      "Resource": "vf:Resource"
+      "role": "https://w3id.org/role/"
     }
   ],
   "@id": "https://rawgit.com/valueflows/resource/master/examples/valueflows.jsonld#id",


### PR DESCRIPTION
I created context.jsonld in this repo and now the only example uses it. Soon we will need to reconsider how to layer contexts and use them in examples but this should do it for now...
