### PR TITLE
Add amount and amountAvailable

### DIFF
--- a/Resource.md
+++ b/Resource.md
@@ -14,6 +14,10 @@ An economic resource, which is useful to people or the ecosystem.
 
 **vf:trackingIdentifier**: For a resource, this can be a serial number for serialized resources (like a computer), or a lot number for batched resources (like a lot of asparagus that will be distributed in smaller quantities but may need to be tracked to its source in case of an e-coli outbreak).  Or it can just be another useful identifier.
 
+**vf:amount**: The quantity and unit of the resource, as defined by the context agent.
+
+**vf:amountAvailable**:  The quantity and unit of the resource that is available for transfers or processes.  This could be a calculated amount based on the vf:amount less the quantity committed or otherwise unable to be promised for a transfer or process.
+
 ## Open Issues
 * Resource stage (where it is based on the last process or transfer made for the same resource in a work flow situation, like Translation@translated, Translation@edited, Translation@proofread). [Issue#30](https://github.com/valueflows/resource/issues/30)
 * Resource access rules


### PR DESCRIPTION
Ref. https://github.com/valueflows/process/issues/7#issuecomment-221329544.

I left onhand amount to be just vf:amount, which for whatever reason was not there yet.  Do people agree this is a good name for the quantity and unit combination from qudt?

I added vf:amountAvailable even though it probably wouldn't be stored in the database, because it might be requested as data, so seemed appropriate for the vocab.

PR so you all can discuss.
